### PR TITLE
Support pd.Series

### DIFF
--- a/pysoleng/solar_geom.py
+++ b/pysoleng/solar_geom.py
@@ -205,11 +205,19 @@ def convert_to_solar_time(
     # Validate `local_standard_time`
     local_ts = validate_datetime(datetime_object=local_standard_time)
 
-    """Ensure local_standard_time has a date, time, and time zone offset.
-    Note that parse will automaticall fill in a date or time if not
-    provided with the current date and 00:00 (for time)."""
+    if isinstance(local_ts, pd.Series):
+        # Ensure local_ts has time zone information
+        if local_ts.dt.tz is None:
+            raise ValueError(
+            """`local_standard_time` must provide a time zone offset,
+            such as `1/1/2019 12:00 PM -06:00`."""
+        )
+
+        # Calculate offset from UTC, using timezone offset in `local_ts`
+        utc_offset = local_ts.dt.tz.utcoffset(local_ts).total_seconds() // 3_600
+    else:
+        # Ensure local_ts has time zone information
     if local_ts.tzinfo is None:
-        # Check that `local_ts` has a timezone offset
         raise ValueError(
             """`local_standard_time` must provide a time zone offset,
             such as `1/1/2019 12:00 PM -06:00`."""
@@ -218,9 +226,10 @@ def convert_to_solar_time(
     # Calculate offset from UTC, using timezone offset in `local_ts`
     utc_offset = local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
 
+
     """Determine the standard meridian for the given `longitude_degrees`,
     which corresponds to 15 degrees per hour offset."""
-    standard_meridian = 15 * abs(utc_offset)
+    standard_meridian = 15 * np.abs(utc_offset)
 
     E = calculate_E_min(
         calculate_B_degrees(calculate_day_number(local_standard_time))

--- a/pysoleng/solar_geom.py
+++ b/pysoleng/solar_geom.py
@@ -424,7 +424,6 @@ def calculate_solar_zenith_degrees(
             )
         )
     )
-    return min(90.0, calculated_zenith)
 
     return np.minimum(calculated_zenith, 90.0)
 

--- a/pysoleng/solar_geom.py
+++ b/pysoleng/solar_geom.py
@@ -217,15 +217,15 @@ def convert_to_solar_time(
         utc_offset = local_ts.dt.tz.utcoffset(local_ts).total_seconds() // 3_600
     else:
         # Ensure local_ts has time zone information
-    if local_ts.tzinfo is None:
-        raise ValueError(
+        if local_ts.tzinfo is None:
+            raise ValueError(
             """`local_standard_time` must provide a time zone offset,
             such as `1/1/2019 12:00 PM -06:00`."""
         )
 
-    # Calculate offset from UTC, using timezone offset in `local_ts`
-    utc_offset = local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
-
+        # Calculate offset from UTC, using timezone offset in `local_ts`
+        utc_offset = local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
+        
 
     """Determine the standard meridian for the given `longitude_degrees`,
     which corresponds to 15 degrees per hour offset."""
@@ -595,18 +595,26 @@ def calculate_solar_noon_in_local_standard_time(
     # Validate `local_standard_time`
     local_ts = validate_datetime(datetime_object=local_standard_time)
 
-    """Ensure local_standard_time has a date, time, and time zone offset.
-    Note that parse will automaticall fill in a date or time if not
-    provided with the current date and 00:00 (for time)."""
-    if local_ts.tzinfo is None:
-        # Check that `local_ts` has a timezone offset
-        raise ValueError(
+    if isinstance(local_ts, pd.Series):
+        # Ensure local_ts has time zone information
+        if local_ts.dt.tz is None:
+            raise ValueError(
             """`local_standard_time` must provide a time zone offset,
             such as `1/1/2019 12:00 PM -06:00`."""
         )
 
-    # Calculate offset from UTC, using timezone offset in `local_ts`
-    utc_offset = local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
+        # Calculate offset from UTC, using timezone offset in `local_ts`
+        utc_offset = local_ts.dt.tz.utcoffset(local_ts).total_seconds() // 3_600
+    else:
+        # Ensure local_ts has time zone information
+        if local_ts.tzinfo is None:
+            raise ValueError(
+            """`local_standard_time` must provide a time zone offset,
+            such as `1/1/2019 12:00 PM -06:00`."""
+        )
+
+        # Calculate offset from UTC, using timezone offset in `local_ts`
+        utc_offset = local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
 
     """Determine the standard meridian for the given `longitude_degrees`,
     which corresponds to 15 degrees per hour offset."""

--- a/pysoleng/solar_geom.py
+++ b/pysoleng/solar_geom.py
@@ -209,23 +209,26 @@ def convert_to_solar_time(
         # Ensure local_ts has time zone information
         if local_ts.dt.tz is None:
             raise ValueError(
-            """`local_standard_time` must provide a time zone offset,
+                """`local_standard_time` must provide a time zone offset,
             such as `1/1/2019 12:00 PM -06:00`."""
-        )
+            )
 
         # Calculate offset from UTC, using timezone offset in `local_ts`
-        utc_offset = local_ts.dt.tz.utcoffset(local_ts).total_seconds() // 3_600
+        utc_offset = (
+            local_ts.dt.tz.utcoffset(local_ts).total_seconds() // 3_600
+        )
     else:
         # Ensure local_ts has time zone information
         if local_ts.tzinfo is None:
             raise ValueError(
-            """`local_standard_time` must provide a time zone offset,
+                """`local_standard_time` must provide a time zone offset,
             such as `1/1/2019 12:00 PM -06:00`."""
-        )
+            )
 
         # Calculate offset from UTC, using timezone offset in `local_ts`
-        utc_offset = local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
-        
+        utc_offset = (
+            local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
+        )
 
     """Determine the standard meridian for the given `longitude_degrees`,
     which corresponds to 15 degrees per hour offset."""
@@ -599,22 +602,26 @@ def calculate_solar_noon_in_local_standard_time(
         # Ensure local_ts has time zone information
         if local_ts.dt.tz is None:
             raise ValueError(
-            """`local_standard_time` must provide a time zone offset,
+                """`local_standard_time` must provide a time zone offset,
             such as `1/1/2019 12:00 PM -06:00`."""
-        )
+            )
 
         # Calculate offset from UTC, using timezone offset in `local_ts`
-        utc_offset = local_ts.dt.tz.utcoffset(local_ts).total_seconds() // 3_600
+        utc_offset = (
+            local_ts.dt.tz.utcoffset(local_ts).total_seconds() // 3_600
+        )
     else:
         # Ensure local_ts has time zone information
         if local_ts.tzinfo is None:
             raise ValueError(
-            """`local_standard_time` must provide a time zone offset,
+                """`local_standard_time` must provide a time zone offset,
             such as `1/1/2019 12:00 PM -06:00`."""
-        )
+            )
 
         # Calculate offset from UTC, using timezone offset in `local_ts`
-        utc_offset = local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
+        utc_offset = (
+            local_ts.tzinfo.utcoffset(local_ts).total_seconds() // 3_600
+        )
 
     """Determine the standard meridian for the given `longitude_degrees`,
     which corresponds to 15 degrees per hour offset."""

--- a/pysoleng/solar_geom.py
+++ b/pysoleng/solar_geom.py
@@ -28,8 +28,10 @@ def calculate_day_number(
     # Ensure `date` can be parsed into a datetime object
     date = validate_datetime(datetime_object=date)
     # Return the day number corresponding to `date`
-    if type(date) is pd.Timestamp:
+    if isinstance(date, pd.Timestamp):
         return date.dayofyear
+    elif isinstance(date, pd.Series):
+        return date.dt.dayofyear
     else:
         return list(date.dayofyear)
 

--- a/pysoleng/solar_geom.py
+++ b/pysoleng/solar_geom.py
@@ -536,7 +536,7 @@ def calculate_solar_azimuth_degrees(
     )
 
     # copysign(x, y) returns `x` with the sign of `y`
-    pre = np.copysign(1, hour_angle_degrees) * abs(
+    pre = np.copysign(1, hour_angle_degrees) * np.abs(
         np.degrees(
             np.arccos(
                 (
@@ -558,7 +558,7 @@ def calculate_solar_azimuth_degrees(
         is directly overhead, which is possible:
         on the equator, on an equinox, at solar noon.
         In this case, just return 0."""
-    if isinstance(pre, np.ndarray):
+    if isinstance(pre, (np.ndarray, pd.Series)):
         pre[~np.isfinite(pre)] = 0.0
     else:
         if not (np.isfinite(pre)):

--- a/tests/solar_geom/test_calculate_day_number.py
+++ b/tests/solar_geom/test_calculate_day_number.py
@@ -31,7 +31,9 @@ def test_calculate_day_number_iterable():
 def test_calculate_day_number_pdseries():
     """Functional test to ensure the calculate_day_number() method
     runs properly on a Pandas series."""
-    x = pd.Series(pd.date_range('2020-01-01 00:00 -07:00', periods=72, freq='H'))
+    x = pd.Series(
+        pd.date_range("2020-01-01 00:00 -07:00", periods=72, freq="H")
+    )
     assert isinstance(calculate_day_number(date=x), pd.Series)
 
 

--- a/tests/solar_geom/test_calculate_day_number.py
+++ b/tests/solar_geom/test_calculate_day_number.py
@@ -28,6 +28,14 @@ def test_calculate_day_number_iterable():
 
 
 @pytest.mark.solar_geom
+def test_calculate_day_number_pdseries():
+    """Functional test to ensure the calculate_day_number() method
+    runs properly on a Pandas series."""
+    x = pd.Series(pd.date_range('2020-01-01 00:00 -07:00', periods=72, freq='H'))
+    assert isinstance(calculate_day_number(date=x), pd.Series)
+
+
+@pytest.mark.solar_geom
 def test_known_values():
     """Run a few tests with known answers to ensure
     calculate_day_number() is giving the expected output."""

--- a/tests/solar_geom/test_calculate_hour_angle_degrees.py
+++ b/tests/solar_geom/test_calculate_hour_angle_degrees.py
@@ -12,8 +12,8 @@ from pysoleng.solar_geom import calculate_hour_angle_degrees
 
 # Create time zone-aware datetimes for use in testing
 aware_datetimes = datetimes(
-    min_value=pd.Timestamp.min,
-    max_value=pd.Timestamp.max,
+    min_value=pd.Timestamp.min + pd.DateOffset(2),
+    max_value=pd.Timestamp.max - pd.DateOffset(2),
     timezones=timezones(),
 )
 

--- a/tests/solar_geom/test_calculate_solar_noon_in_local_standard_time.py
+++ b/tests/solar_geom/test_calculate_solar_noon_in_local_standard_time.py
@@ -68,11 +68,12 @@ def test_calculate_solar_noon_in_local_standard_time_iterable():
     """Functional test to ensure the
     calculate_solar_noon_in_local_standard_time() method
     runs properly given a Pandas series."""
-    x = pd.Series(pd.date_range('2020-01-01 00:00 -07:00', periods=72, freq='H'))
+    x = pd.Series(
+        pd.date_range("2020-01-01 00:00 -07:00", periods=72, freq="H")
+    )
     assert isinstance(
         calculate_solar_noon_in_local_standard_time(
-            local_standard_time=x,
-            longitude_degrees=89.4,
+            local_standard_time=x, longitude_degrees=89.4,
         ),
         np.ndarray,
     )
@@ -113,11 +114,10 @@ def test_naive_datetime():
             local_standard_time="February 3, 2020 10:30 AM",
             longitude_degrees=89.4,
         )
-    x = pd.Series(pd.date_range('2020-01-01 00:00', periods=72, freq='H'))
+    x = pd.Series(pd.date_range("2020-01-01 00:00", periods=72, freq="H"))
     with pytest.raises(ValueError):
         assert calculate_solar_noon_in_local_standard_time(
-            local_standard_time=x,
-            longitude_degrees=89.4
+            local_standard_time=x, longitude_degrees=89.4
         )
 
 

--- a/tests/solar_geom/test_calculate_solar_noon_in_local_standard_time.py
+++ b/tests/solar_geom/test_calculate_solar_noon_in_local_standard_time.py
@@ -64,6 +64,21 @@ def test_calculate_solar_noon_in_local_standard_time_iterable():
 
 
 @pytest.mark.solar_geom
+def test_calculate_solar_noon_in_local_standard_time_iterable():
+    """Functional test to ensure the
+    calculate_solar_noon_in_local_standard_time() method
+    runs properly given a Pandas series."""
+    x = pd.Series(pd.date_range('2020-01-01 00:00 -07:00', periods=72, freq='H'))
+    assert isinstance(
+        calculate_solar_noon_in_local_standard_time(
+            local_standard_time=x,
+            longitude_degrees=89.4,
+        ),
+        np.ndarray,
+    )
+
+
+@pytest.mark.solar_geom
 def test_known_values():
     """Run a test with a known answer to ensure
     calculate_solar_noon_in_local_standard_time()
@@ -97,6 +112,12 @@ def test_naive_datetime():
         assert calculate_solar_noon_in_local_standard_time(
             local_standard_time="February 3, 2020 10:30 AM",
             longitude_degrees=89.4,
+        )
+    x = pd.Series(pd.date_range('2020-01-01 00:00', periods=72, freq='H'))
+    with pytest.raises(ValueError):
+        assert calculate_solar_noon_in_local_standard_time(
+            local_standard_time=x,
+            longitude_degrees=89.4
         )
 
 

--- a/tests/solar_geom/test_convert_to_solar_time.py
+++ b/tests/solar_geom/test_convert_to_solar_time.py
@@ -61,6 +61,20 @@ def test_convert_to_solar_time_iterable():
 
 
 @pytest.mark.solar_geom
+def test_convert_to_solar_time_pdseries():
+    """Functional test to ensure the convert_to_solar_time() method
+    runs properly given a Pandas series."""
+    x = pd.Series(pd.date_range('2020-01-01 00:00 -07:00', periods=72, freq='H'))
+    assert isinstance(
+        convert_to_solar_time(
+            local_standard_time=x,
+            longitude_degrees=89.4,
+        ),
+        list,
+    )
+
+
+@pytest.mark.solar_geom
 def test_known_values():
     """Run a test with a known answer to ensure
     convert_to_solar_time() is giving the expected output
@@ -86,6 +100,12 @@ def test_naive_datetime():
         assert convert_to_solar_time(
             local_standard_time="February 3, 2020 10:30 AM",
             longitude_degrees=89.4,
+        )
+    x = pd.Series(pd.date_range('2020-01-01 00:00', periods=72, freq='H'))
+    with pytest.raises(ValueError):
+        assert convert_to_solar_time(
+            local_standard_time=x,
+            longitude_degrees=89.4
         )
 
 

--- a/tests/solar_geom/test_convert_to_solar_time.py
+++ b/tests/solar_geom/test_convert_to_solar_time.py
@@ -64,12 +64,11 @@ def test_convert_to_solar_time_iterable():
 def test_convert_to_solar_time_pdseries():
     """Functional test to ensure the convert_to_solar_time() method
     runs properly given a Pandas series."""
-    x = pd.Series(pd.date_range('2020-01-01 00:00 -07:00', periods=72, freq='H'))
+    x = pd.Series(
+        pd.date_range("2020-01-01 00:00 -07:00", periods=72, freq="H")
+    )
     assert isinstance(
-        convert_to_solar_time(
-            local_standard_time=x,
-            longitude_degrees=89.4,
-        ),
+        convert_to_solar_time(local_standard_time=x, longitude_degrees=89.4,),
         list,
     )
 
@@ -101,11 +100,10 @@ def test_naive_datetime():
             local_standard_time="February 3, 2020 10:30 AM",
             longitude_degrees=89.4,
         )
-    x = pd.Series(pd.date_range('2020-01-01 00:00', periods=72, freq='H'))
+    x = pd.Series(pd.date_range("2020-01-01 00:00", periods=72, freq="H"))
     with pytest.raises(ValueError):
         assert convert_to_solar_time(
-            local_standard_time=x,
-            longitude_degrees=89.4
+            local_standard_time=x, longitude_degrees=89.4
         )
 
 


### PR DESCRIPTION
PR to add support for pd.Series in response to issue #9.  Now all methods in pysoleng.utils and pysoleng.solar_geom can work with pd.Series (along with NumPy ndarrays, and single values).